### PR TITLE
Update org.kde.Sdk to 5.15-21.08

### DIFF
--- a/org.citra_emu.citra.json
+++ b/org.citra_emu.citra.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.citra_emu.citra",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.15",
+    "runtime-version": "5.15-21.08",
     "sdk": "org.kde.Sdk",
     "command": "citra-qt",
     "rename-desktop-file": "citra.desktop",


### PR DESCRIPTION
This is required to get an updated SDL, which contains features used by the latest version of Citra.

Marked as a draft as it depends on https://github.com/flathub/buildbot-config/pull/78