### PR TITLE
Fix build

### DIFF
--- a/org.citra_emu.citra.json
+++ b/org.citra_emu.citra.json
@@ -11,7 +11,7 @@
             "CI": "1",
             "GITHUB_ACTIONS": "1",
             "GITHUB_REPOSITORY": "citra-emu/citra-nightly",
-            "GIT_TAG_NAME": "nightly-1877"
+            "GITHUB_REF_NAME": "nightly-1877"
         }
     },
     "finish-args": [


### PR DESCRIPTION
After PR https://github.com/citra-emu/citra/pull/6358 GIT_TAG_NAME was renamed to GITHUB_REF_NAME 