### PR TITLE
Bump runtime version to 6.4

### DIFF
--- a/org.citra_emu.citra.json
+++ b/org.citra_emu.citra.json
@@ -11,7 +11,7 @@
             "CI": "1",
             "GITHUB_ACTIONS": "1",
             "GITHUB_REPOSITORY": "citra-emu/citra-nightly",
-            "GITHUB_REF_NAME": "nightly-1898"
+            "GITHUB_REF_NAME": "nightly-1904"
         }
     },
     "finish-args": [
@@ -78,8 +78,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/citra-emu/citra-nightly/releases/download/nightly-1898/citra-unified-source-20230504-70335a7.tar.xz",
-                    "sha256": "b320585bd8c4c075f63d3d9c74b830718e58fcf04d987a5dcead402a72abf753",
+                    "url": "https://github.com/citra-emu/citra-nightly/releases/download/nightly-1904/citra-unified-source-20230511-dc39eac.tar.xz",
+                    "sha256": "7db2c2c199889e43cad06216f1d9acd54ba0e206e716d779d15548d06066ce65",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/citra-emu/citra-nightly/releases/latest",

--- a/org.citra_emu.citra.json
+++ b/org.citra_emu.citra.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.citra_emu.citra",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.15-22.08",
+    "runtime-version": "6.4",
     "sdk": "org.kde.Sdk",
     "command": "citra-qt",
     "rename-desktop-file": "citra.desktop",

--- a/org.citra_emu.citra.metainfo.xml
+++ b/org.citra_emu.citra.metainfo.xml
@@ -32,6 +32,7 @@
     <screenshot>https://raw.githubusercontent.com/citra-emu/citra-web/master/images/screenshots/35-Pok%C3%A9mon%20ORAS.png</screenshot>
   </screenshots>
   <releases>
+    <release version="nightly-1904" date="2023-05-12"/>
     <release version="nightly-1898" date="2023-05-05"/>
     <release version="nightly-1897" date="2023-05-04"/>
     <release version="nightly-1896" date="2023-05-02"/>


### PR DESCRIPTION
Bumps the runtime version to 6.4 to fix build, as Citra has moved to Qt 6.

The platform and runtime 6.4 were already added to the linux-flatpak build image previously: https://github.com/citra-emu/build-environments/blob/master/linux-flatpak/Dockerfile#LL7C85-L7C123

Also bumps us up to the latest nightly, 1904, since the current 1898 is from before Qt 6. Thus we can't build successfully without both of these updates at once.