### PR TITLE
Update desktop file name.

### DIFF
--- a/org.citra_emu.citra.json
+++ b/org.citra_emu.citra.json
@@ -4,7 +4,7 @@
     "runtime-version": "6.5",
     "sdk": "org.kde.Sdk",
     "command": "citra-qt",
-    "rename-desktop-file": "citra.desktop",
+    "rename-desktop-file": "citra-qt.desktop",
     "rename-icon": "citra",
     "build-options": {
         "env": {
@@ -66,8 +66,8 @@
             ],
             "post-install": [
                 "install -Dm644 ../org.citra_emu.citra.metainfo.xml /app/share/appdata/org.citra_emu.citra.metainfo.xml",
-                "desktop-file-install --dir=/app/share/applications ../dist/citra.desktop",
-                "echo 'StartupWMClass=citra-qt' >> /app/share/applications/citra.desktop",
+                "desktop-file-install --dir=/app/share/applications ../dist/citra-qt.desktop",
+                "echo 'StartupWMClass=citra-qt' >> /app/share/applications/citra-qt.desktop",
                 "install -Dm644 ../org.citra_emu.citra.svg /app/share/icons/hicolor/scalable/apps/citra.svg",
                 "install -Dm644 ../dist/icon.png /app/share/icons/hicolor/512x512/apps/citra.png",
                 "mv /app/share/mime/packages/citra.xml /app/share/mime/packages/org.citra_emu.citra.xml",

--- a/org.citra_emu.citra.metainfo.xml
+++ b/org.citra_emu.citra.metainfo.xml
@@ -15,7 +15,7 @@
   <launchable type="desktop-id">org.citra_emu.citra.desktop</launchable>
   <provides>
     <binary>citra-qt</binary>
-    <id>citra.desktop</id>
+    <id>citra-qt.desktop</id>
   </provides>
   <url type="homepage">https://citra-emu.org/</url>
   <url type="translate">https://www.transifex.com/citra/citra/</url>


### PR DESCRIPTION
The citra-qt desktop file got renamed as we now have desktops for all 3 of citra, citra-qt, and citra-room in the repository. This is because generating AppImage files for all 3 in our AppImage builds requires desktop files for each.

Tested building and launching shortcut on Ubuntu 23.04

Fixes https://github.com/flathub/org.citra_emu.citra/issues/469