### PR TITLE
Disable Wayland, enable ARM64, and update CMake arguments.

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "skip-arches": ["i386","arm","aarch64"]
+  "skip-arches": ["i386","arm"]
 }

--- a/org.citra_emu.citra.json
+++ b/org.citra_emu.citra.json
@@ -16,8 +16,7 @@
     },
     "finish-args": [
         "--device=all",
-        "--socket=wayland",
-        "--socket=fallback-x11",
+        "--socket=x11",
         "--socket=pulseaudio",
         "--share=network",
         "--share=ipc",
@@ -52,13 +51,10 @@
             "builddir": true,
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=Release",
-                "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON",
-                "-DENABLE_LTO=ON",
                 "-DENABLE_QT_TRANSLATION=ON",
                 "-DCITRA_ENABLE_COMPATIBILITY_REPORTING=ON",
                 "-DENABLE_COMPATIBILITY_LIST_DOWNLOAD=OFF",
-                "-DUSE_SYSTEM_SDL2=ON",
-                "-DCMAKE_POLICY_DEFAULT_CMP0069=NEW"
+                "-DUSE_SYSTEM_SDL2=ON"
             ],
             "cleanup": [
                 "/share/man",


### PR DESCRIPTION
* Disable the Wayland socket as Citra has issues with Wayland currently. We want to use XWayland until this is fixed, as in the AppImage.
* Enable ARM64 builds, since Citra supports it now and we can get support from FlatHub builders for free.
* Update the CMake arguments. LTO is no longer needed since we enable it for all Release builds, and we control interprocedural optimizations using that flag. Similarly the LTO-related policy CMP0069 behavior no longer needs to be manually specified.