### PR TITLE
Work around host VK_DRIVER_FILES/VK_ICD_FILENAMES breaking Vulkan inside flatpak sandbox.

### DIFF
--- a/citra-launcher.sh
+++ b/citra-launcher.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+report_error() {
+    read -r -d '|' MESSAGE <<EOF
+Unfortunately, Citra seems to have crashed.
+We kindly ask you to submit a bug report to <a href="https://github.com/flathub/org.citra_emu.citra/issues">https://github.com/flathub/org.citra_emu.citra/issues</a>.
+
+When submitting a bug report, please attach your <b>system information</b> and the <b>Citra log file</b>.
+You seem to be using ${XDG_SESSION_DESKTOP} ${DESKTOP_SESSION} (${XDG_SESSION_TYPE}):
+To obtain Citra log files, please see <a href="https://community.citra-emu.org/t/how-to-upload-the-log-file/296">this guide</a>.
+To obtain your system information, please install <tt>inxi</tt> and run <tt>inxi -v3</tt>. |
+EOF
+    zenity --warning --no-wrap --title "That's awkward ..." --text "$MESSAGE"
+}
+
+export QT_QPA_PLATFORM=xcb
+unset VK_ICD_FILENAMES VK_DRIVER_FILES
+# Discord RPC
+for i in {0..9}; do
+    test -S "$XDG_RUNTIME_DIR"/"discord-ipc-$i" || ln -sf {app/com.discordapp.Discord,"$XDG_RUNTIME_DIR"}/"discord-ipc-$i";
+done
+
+
+if ! prlimit --nofile=8192 citra-qt "$@"; then
+    report_error
+fi

--- a/org.citra_emu.citra.json
+++ b/org.citra_emu.citra.json
@@ -20,7 +20,8 @@
         "--socket=pulseaudio",
         "--share=network",
         "--share=ipc",
-        "--filesystem=host:ro"
+        "--filesystem=host:ro",
+        "--filesystem=xdg-run/app/com.discordapp.Discord:ro"
     ],
     "modules": [
         "shared-modules/libusb/libusb.json",
@@ -53,6 +54,7 @@
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DENABLE_QT_TRANSLATION=ON",
                 "-DCITRA_ENABLE_COMPATIBILITY_REPORTING=ON",
+                "-DUSE_DISCORD_PRESENCE=ON",
                 "-DENABLE_COMPATIBILITY_LIST_DOWNLOAD=OFF",
                 "-DUSE_SYSTEM_SDL2=ON"
             ],

--- a/org.citra_emu.citra.json
+++ b/org.citra_emu.citra.json
@@ -47,6 +47,31 @@
             ]
         },
         {
+            "name": "rapidjson",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DRAPIDJSON_ENABLE_INSTRUMENTATION_OPT=OFF",
+                "-DRAPIDJSON_BUILD_DOC=OFF",
+                "-DRAPIDJSON_BUILD_EXAMPLES=OFF",
+                "-DRAPIDJSON_BUILD_TESTS=OFF",
+                "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz",
+                    "sha256": "bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "stable-only": true,
+                        "project-id": 7422,
+                        "url-template": "https://github.com/Tencent/rapidjson/archive/v$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
             "name": "citra",
             "buildsystem": "cmake-ninja",
             "builddir": true,

--- a/org.citra_emu.citra.json
+++ b/org.citra_emu.citra.json
@@ -3,7 +3,7 @@
     "runtime": "org.kde.Platform",
     "runtime-version": "6.5",
     "sdk": "org.kde.Sdk",
-    "command": "citra-qt",
+    "command": "citra-launcher",
     "rename-desktop-file": "citra-qt.desktop",
     "rename-icon": "citra",
     "build-options": {
@@ -61,9 +61,10 @@
                 "/share/pixmaps"
             ],
             "post-install": [
+                "install -Dm755 ../citra-launcher.sh /app/bin/citra-launcher",
                 "install -Dm644 ../org.citra_emu.citra.metainfo.xml /app/share/appdata/org.citra_emu.citra.metainfo.xml",
                 "desktop-file-install --dir=/app/share/applications ../dist/citra-qt.desktop",
-                "echo 'StartupWMClass=citra-qt' >> /app/share/applications/citra-qt.desktop",
+                "desktop-file-edit --set-key StartupWMClass --set-value citra-qt --set-key Exec --set-value citra-launcher /app/share/applications/citra-qt.desktop",
                 "install -Dm644 ../org.citra_emu.citra.svg /app/share/icons/hicolor/scalable/apps/citra.svg",
                 "install -Dm644 ../dist/icon.png /app/share/icons/hicolor/512x512/apps/citra.png",
                 "mv /app/share/mime/packages/citra.xml /app/share/mime/packages/org.citra_emu.citra.xml",
@@ -89,6 +90,10 @@
                 {
                     "type": "file",
                     "path": "org.citra_emu.citra.svg"
+                },
+                {
+                    "type": "file",
+                    "path": "citra-launcher.sh"
                 }
             ]
         }


### PR DESCRIPTION
If a host system has VK_DRIVER_FILES or VK_ICD_FILENAMES set, it can break Vulkan inside the sandbox as it will be pointing to host driver files which don't exist there. Work around this by unsetting these variables in a launcher script.

I have submitted a PR to flatpak itself to try to properly fix this issue: https://github.com/flatpak/flatpak/pull/5553 However we will probably need this workaround for a long while while distro versions catch up, if it gets accepted.